### PR TITLE
Fix missing toolchain error when building dashboard

### DIFF
--- a/dashboard/go.mod
+++ b/dashboard/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-metal3/metal-tools/dashboard
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/adrg/xdg v0.5.3


### PR DESCRIPTION
When running make the error `toolchain not available` appears
Making it explicit the subversion of GO to use will fix that.